### PR TITLE
Remove duplicate condition in if-stmt

### DIFF
--- a/plugins/in_proc/in_proc.c
+++ b/plugins/in_proc/in_proc.c
@@ -182,8 +182,8 @@ static int configure(struct flb_in_proc_config *ctx,
 
 static int get_pid_status(pid_t pid)
 {
-    int ret =  kill(pid, 0);
-    return ((ret != ESRCH)  && (ret != EPERM) && (ret != ESRCH));
+    int ret = kill(pid, 0);
+    return ((ret != ESRCH) && (ret != EPERM));
 }
 
 static int generate_record_linux(struct flb_input_instance *i_ins,


### PR DESCRIPTION
<!-- Provide summary of changes -->

Last condition is superfluous and can be removed: ` && (ret != ESRCH)`

```c
183    static int get_pid_status(pid_t pid)
184    {
185        int ret =  kill(pid, 0);
186        return ((ret != ESRCH)  && (ret != EPERM) && (ret != ESRCH));
                   ^^^^^^^^^^^^^^ duplicated conditions ^^^^^^^^^^^^^^
187    }
```

https://github.com/fluent/fluent-bit/blob/master/plugins/in_proc/in_proc.c#L186

I could not figure out which sub-system this belonged to, so my commit-message is probably wrong. I'm sorry about that.


<!-- Issue number, if available. E.g. "Fixes #31", "Addresses #42, #77" -->

----
Enter `[N/A]` in the box, if an item is not applicable to your change.

**Testing**
Before we can approve your change; please submit the following in a comment:
- [N/A] Example configuration file for the change
- [N/A] Debug log output from testing the change
<!-- Invoke Fluent Bit and Valgrind as: $ valgrind ./bin/fluent-bit <args> -->
- [N/A] Attached [Valgrind](https://valgrind.org/docs/manual/quick-start.html) output that shows no leaks or memory corruption was found

If this is a change to packaging of containers or native binaries then please confirm it works for all targets.
- [N/A] Attached [local packaging test](./packaging/local-build-all.sh) output showing all targets (including any new ones) build.

**Documentation**
<!-- Docs can be edited at https://github.com/fluent/fluent-bit-docs -->
- [N/A] Documentation required for this feature

<!--  Doc PR (not required but highly recommended) -->

**Backporting**
<!--
PRs targeting the default master branch will go into the next major release usually.
If this PR should be backported to the current or earlier releases then please submit a PR for that particular branch.
-->
- [N/A] Backport to latest stable release.

<!--  Other release PR (not required but highly recommended for quick turnaround) -->
----

Fluent Bit is licensed under Apache 2.0, by submitting this pull request I understand that this code will be released under the terms of that license.
